### PR TITLE
0.23.0 to 0.26.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ $> docker run --rm -it -v /home/moti/projects/myapp:/app motiz88/flow bash
 If you'd rather not keep a dedicated Bash window open, it should also be possible to, say, run the container in the background and `docker exec <container_id> flow` into it as needed.
 
 ## More information
-This GitHub repo is built automatically as [motiz88/flow](https://registry.hub.docker.com/u/motiz88/flow) on Docker Hub. More instructions for use are available there.
+This GitHub repo is built automatically as [motiz88/flow](https://registry.hub.docker.com/r/motiz88/flow) on Docker Hub. More instructions for use are available there.

--- a/sync-releases.js
+++ b/sync-releases.js
@@ -35,7 +35,7 @@ function getReleases(cb) {
 }
 
 function isUsableRelease(release) {
-    return !release.draft && release.name !== '' && release.tag_name !== '' && !release.prerelease;
+    return !release.draft && release.tag_name !== '' && !release.prerelease;
 }
 
 function isUsableAsset(asset) {
@@ -76,8 +76,8 @@ getReleases(function(err, releases) {
             if (assets.length < 1)
                 return;
             var dockerfileSource = getDockerfileSourceForAsset(assets[0]);
-            
-            var outputDir = release.name;
+
+            var outputDir = release.tag_name;
             try {
             	fs.mkdirSync(outputDir);
             }

--- a/v0.23.0/Dockerfile
+++ b/v0.23.0/Dockerfile
@@ -1,0 +1,17 @@
+FROM buildpack-deps:jessie-curl
+
+RUN apt-get update \
+	&& apt-get install -y unzip libelf1 \
+	&& apt-get clean \
+	&& rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+	&& curl -SL "https://github.com/facebook/flow/releases/download/v0.23.0/flow-linux64-v0.23.0.zip" -o "flow-linux64-v0.23.0.zip" \
+	&& unzip "flow-linux64-v0.23.0.zip" -d /usr/local \
+	&& rm "flow-linux64-v0.23.0.zip"
+
+
+ENV PATH /usr/local/flow:$PATH
+
+VOLUME /app
+WORKDIR /app
+
+CMD ["flow", "check"]

--- a/v0.23.1/Dockerfile
+++ b/v0.23.1/Dockerfile
@@ -1,0 +1,17 @@
+FROM buildpack-deps:jessie-curl
+
+RUN apt-get update \
+	&& apt-get install -y unzip libelf1 \
+	&& apt-get clean \
+	&& rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+	&& curl -SL "https://github.com/facebook/flow/releases/download/v0.23.1/flow-linux64-v0.23.1.zip" -o "flow-linux64-v0.23.1.zip" \
+	&& unzip "flow-linux64-v0.23.1.zip" -d /usr/local \
+	&& rm "flow-linux64-v0.23.1.zip"
+
+
+ENV PATH /usr/local/flow:$PATH
+
+VOLUME /app
+WORKDIR /app
+
+CMD ["flow", "check"]

--- a/v0.24.0/Dockerfile
+++ b/v0.24.0/Dockerfile
@@ -1,0 +1,17 @@
+FROM buildpack-deps:jessie-curl
+
+RUN apt-get update \
+	&& apt-get install -y unzip libelf1 \
+	&& apt-get clean \
+	&& rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+	&& curl -SL "https://github.com/facebook/flow/releases/download/v0.24.0/flow-linux64-v0.24.0.zip" -o "flow-linux64-v0.24.0.zip" \
+	&& unzip "flow-linux64-v0.24.0.zip" -d /usr/local \
+	&& rm "flow-linux64-v0.24.0.zip"
+
+
+ENV PATH /usr/local/flow:$PATH
+
+VOLUME /app
+WORKDIR /app
+
+CMD ["flow", "check"]

--- a/v0.24.1/Dockerfile
+++ b/v0.24.1/Dockerfile
@@ -1,0 +1,17 @@
+FROM buildpack-deps:jessie-curl
+
+RUN apt-get update \
+	&& apt-get install -y unzip libelf1 \
+	&& apt-get clean \
+	&& rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+	&& curl -SL "https://github.com/facebook/flow/releases/download/v0.24.1/flow-linux64-v0.24.1.zip" -o "flow-linux64-v0.24.1.zip" \
+	&& unzip "flow-linux64-v0.24.1.zip" -d /usr/local \
+	&& rm "flow-linux64-v0.24.1.zip"
+
+
+ENV PATH /usr/local/flow:$PATH
+
+VOLUME /app
+WORKDIR /app
+
+CMD ["flow", "check"]

--- a/v0.24.2/Dockerfile
+++ b/v0.24.2/Dockerfile
@@ -1,0 +1,17 @@
+FROM buildpack-deps:jessie-curl
+
+RUN apt-get update \
+	&& apt-get install -y unzip libelf1 \
+	&& apt-get clean \
+	&& rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+	&& curl -SL "https://github.com/facebook/flow/releases/download/v0.24.2/flow-linux64-v0.24.2.zip" -o "flow-linux64-v0.24.2.zip" \
+	&& unzip "flow-linux64-v0.24.2.zip" -d /usr/local \
+	&& rm "flow-linux64-v0.24.2.zip"
+
+
+ENV PATH /usr/local/flow:$PATH
+
+VOLUME /app
+WORKDIR /app
+
+CMD ["flow", "check"]

--- a/v0.25.0/Dockerfile
+++ b/v0.25.0/Dockerfile
@@ -1,0 +1,17 @@
+FROM buildpack-deps:jessie-curl
+
+RUN apt-get update \
+	&& apt-get install -y unzip libelf1 \
+	&& apt-get clean \
+	&& rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+	&& curl -SL "https://github.com/facebook/flow/releases/download/v0.25.0/flow-linux64-v0.25.0.zip" -o "flow-linux64-v0.25.0.zip" \
+	&& unzip "flow-linux64-v0.25.0.zip" -d /usr/local \
+	&& rm "flow-linux64-v0.25.0.zip"
+
+
+ENV PATH /usr/local/flow:$PATH
+
+VOLUME /app
+WORKDIR /app
+
+CMD ["flow", "check"]

--- a/v0.26.0/Dockerfile
+++ b/v0.26.0/Dockerfile
@@ -1,0 +1,17 @@
+FROM buildpack-deps:jessie-curl
+
+RUN apt-get update \
+	&& apt-get install -y unzip libelf1 \
+	&& apt-get clean \
+	&& rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+	&& curl -SL "https://github.com/facebook/flow/releases/download/v0.26.0/flow-linux64-v0.26.0.zip" -o "flow-linux64-v0.26.0.zip" \
+	&& unzip "flow-linux64-v0.26.0.zip" -d /usr/local \
+	&& rm "flow-linux64-v0.26.0.zip"
+
+
+ENV PATH /usr/local/flow:$PATH
+
+VOLUME /app
+WORKDIR /app
+
+CMD ["flow", "check"]


### PR DESCRIPTION
Update with releases to 0.26.0.

Fixed an issue where all v0.24.\* versions would not be generated.
